### PR TITLE
fix: change range of phi, theta (not really necessary for PCC control…

### DIFF
--- a/SoftTrunk/include/CurvatureCalculator.h
+++ b/SoftTrunk/include/CurvatureCalculator.h
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <iostream>
 #include <thread>
+#include <cmath>
 
 class CurvatureCalculator {
   /*

--- a/SoftTrunk/include/SoftTrunk_common_defs.h
+++ b/SoftTrunk/include/SoftTrunk_common_defs.h
@@ -14,11 +14,12 @@
 #define NUM_ELEMENTS 3 // how many PCC elements there are
 #define CHARACTERIZE_STEPS 20 // Used in characterization- how many time steps to spend on each bend
 #define TIME_STEP 100 // milliseconds of each time step
-#define LOCAL_ADDRESS "192.168.1.194"
+#define LOCAL_ADDRESS "192.168.1.111"
 #define MOTIVE_ADDRESS "192.168.1.105"
 #define VALVE_ADDRESS "192.168.1.101"
-#define PRESSURE_OFFSET 800 // baseline pressure of arm.
+#define PRESSURE_OFFSET 700 // baseline pressure of arm.
 #define USE_PID_CURVATURE_CONTROL true
+#define PI 3.141592
 
 typedef Eigen::Matrix<double,NUM_ELEMENTS*2,1> Vector2Nd;
 typedef Eigen::Matrix<double,NUM_ELEMENTS*2,NUM_ELEMENTS*2> Matrix2Nd;

--- a/SoftTrunk/src/ControllerPCC.cpp
+++ b/SoftTrunk/src/ControllerPCC.cpp
@@ -9,10 +9,17 @@ ControllerPCC::ControllerPCC(AugmentedRigidArm* augmentedRigidArm, SoftArm* soft
 }
 
 ControllerPCC::ControllerPCC(SoftArm* softArm) : sa(softArm){
-    for (int i = 0; i < NUM_ELEMENTS; ++i) {
-        miniPIDs.push_back(MiniPID(0,0,0)); // PID for phi
-        miniPIDs.push_back(MiniPID(150,0.2,0)); // PID for theta
-    }
+//    for (int i = 0; i < NUM_ELEMENTS; ++i) {
+//        miniPIDs.push_back(MiniPID(0,0,0)); // PID for phi
+//        miniPIDs.push_back(MiniPID(150,0,0)); // PID for theta
+//    }
+    miniPIDs.push_back(MiniPID(100,0,0)); // PID for phi
+    miniPIDs.push_back(MiniPID(300,0,0)); // PID for theta
+    miniPIDs.push_back(MiniPID(100,0,0)); // PID for phi
+    miniPIDs.push_back(MiniPID(300,0,0)); // PID for theta
+    miniPIDs.push_back(MiniPID(100,0,0)); // PID for phi
+    miniPIDs.push_back(MiniPID(300,0,0)); // PID for theta
+
 }
 
 void ControllerPCC::curvatureDynamicControl(const Vector2Nd &q_ref,
@@ -38,6 +45,6 @@ void ControllerPCC::curvatureDynamicControl(
 
 void ControllerPCC::curvaturePIDControl(const Vector2Nd &q_ref, Vector2Nd *output) {
     for (int i = 0; i < 2 * NUM_ELEMENTS; ++i) {
-        (*output)(i) = miniPIDs[i].getOutput(sa->curvatureCalculator->q(i), q_ref[i]);
+        (*output)(i) = miniPIDs[i].getOutput(sa->curvatureCalculator->q(i), q_ref(i));
     }
 }

--- a/SoftTrunk/src/CurvatureCalculator.cpp
+++ b/SoftTrunk/src/CurvatureCalculator.cpp
@@ -82,9 +82,12 @@ void CurvatureCalculator::calculateCurvature() {
     Eigen::Transform<double, 3, Eigen::Affine>::MatrixType matrix = rel_transforms[i].matrix();
     q(i*2) = atan(matrix(1,3)/matrix(0,3)); // -PI/2 ~ PI/2
     q(i*2+1) = sign(matrix(0,3)) * (asin(sqrt(pow(matrix(0,2),2) + pow(matrix(1,2),2))));
-    if (q(i*2) < 0){
+    if (q(i*2+1)<0){
       q(i*2+1) = -q(i*2+1);
-      q(i*2) += 3.1415;
+      q(i*2) += 3.14;
+    }
+    if (q(i*2) < 0){
+      q(i*2) += 2 * 3.1415;
     }
   }
 }

--- a/SoftTrunk/src/SoftArm.cpp
+++ b/SoftTrunk/src/SoftArm.cpp
@@ -38,9 +38,16 @@ void SoftArm::actuate(Vector2Nd tau_pt, Vector2Nd ref_q) {
     double theta;
     for (int i = 0; i < NUM_ELEMENTS; ++i) {
         //todo: why is this matrix operation the way it is?
-        phi = ref_q(2*i);
-        theta = ref_q(2*i+1);
-        if (true){//theta < 3.14/36){
+        theta = curvatureCalculator->q(2*i+1);
+        if (true){//(theta < 0.1){
+            // sensor reading for phi is unstable when theta is small
+            phi = ref_q(2*i);
+        }
+        else{
+            phi = curvatureCalculator->q(2*i);
+        }
+
+        if (true){//(theta < 0.1){
             mat << 0, -sin(phi), 0, cos(phi);
         }
         else {

--- a/SoftTrunk/src/SoftTrunkManager.cpp
+++ b/SoftTrunk/src/SoftTrunkManager.cpp
@@ -23,7 +23,18 @@ void SoftTrunkManager::curvatureControl(Vector2Nd q,
                                         Vector2Nd ddq) {
     // get current measured state from CurvatureCalculator inside SoftArm, send that to ControllerPCC
     // actuate the arm with the tau value.
+
+
     if (USE_PID_CURVATURE_CONTROL){
+        // sanitize q before sending to controller
+        for (int j = 0; j < NUM_ELEMENTS; ++j) {
+            if (q(2*j+1) < 0){
+                q(2*j) += 3.1415;
+                q(2*j+1) = -q(2*j+1);
+            }
+            q(2*j) = fmod(q(2*j), 3.1415*2);
+        }
+
         Vector2Nd output;
         controllerPCC->curvaturePIDControl(q,&output);
         //std::cout << output << "\n";

--- a/SoftTrunk/src/example_sinusoidal.cpp
+++ b/SoftTrunk/src/example_sinusoidal.cpp
@@ -3,13 +3,12 @@
 #include <cmath>
 #include <iostream>
 #include <thread>
-#define PI 3.141592
 /*
 sends a sinusoidal wave to 4 actuators, and each phase is offset by PI/2.
 */
 void wait() { std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
 
-int sinusoid(double t) { return 200 + 200 * sin(t); }
+int sinusoid(double t) { return 700 + 500 * sin(t); }
 int main() {
   ForceController forceController(16, 1000);
 

--- a/SoftTrunk/src/experiment.cpp
+++ b/SoftTrunk/src/experiment.cpp
@@ -4,8 +4,8 @@
 
 #include "SoftTrunkManager.h"
 #include <Eigen/Dense>
-#define STEPS 5000
-#define STEP_TIME 0.005
+#define STEPS 10000
+#define STEP_TIME 0.002
 
 #include "SoftTrunk_common_defs.h"
 
@@ -14,15 +14,26 @@ int main(){
     Vector2Nd q = Vector2Nd::Zero();
     Vector2Nd dq = Vector2Nd::Zero();
     Vector2Nd ddq = Vector2Nd::Zero();
+    std::cout << q <<"\n";
     double seconds;
 
     for (int j = 0; j < STEPS; ++j) {
         seconds += STEP_TIME;
-        if (j % 200 == 0) std::cout<<"200 steps\n";
+//        if (j % 200 == 0) std::cout<<"200 steps\n";
         //q(0) = seconds;
         //q(1) = 0.5*sin(seconds);
-        q(4) = seconds/2;
-        q(5) = 0.5;//*sin(seconds);
+        q(0) = PI + PI*0.9 * sin(seconds);
+        q(1) = 0.5;
+
+//        q(2) = seconds/2.5;
+//        q(3) = 0.5;
+//
+//        q(4) = seconds/2;
+//        q(5) = 0.5;//*sin(seconds);
+//        q(1) = 0.4*sin(seconds);
+//        q(3) = -0.6*sin(seconds);
+//        q(3) = 0.7;//*sin(seconds);
+//        q(2) = seconds/2;
         stm.curvatureControl(q, dq, ddq);
         std::this_thread::sleep_for(std::chrono::milliseconds(int(STEP_TIME*1000)));
     }


### PR DESCRIPTION
… but should be considered in PID control so values don't jump around)

fix: phi of actual curvature will be used in actuate() in SoftArm.cpp, if theta is large enough